### PR TITLE
Add AgentWallet SDK to SDKs and Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Ollama Python](https://github.com/ollama/ollama-python) - Python library for running and interacting with local LLMs via the Ollama runtime.
 - [LiteLLM](https://github.com/BerriAI/litellm) - Unified interface to call 100+ LLM APIs using the OpenAI format with load balancing and spend tracking.
 - [Marvin](https://github.com/prefecthq/marvin) - Lightweight AI engineering toolkit for building natural language interfaces and AI functions.
+- [AgentWallet SDK](https://github.com/up2itnow0822/agentwallet-sdk) - Non-custodial wallet SDK for AI agents with x402 payments, CCTP cross-chain bridging, and SpendingPolicy guardrails.
 
 ## Standards and Specifications
 


### PR DESCRIPTION
Adds [AgentWallet SDK](https://github.com/up2itnow0822/agentwallet-sdk) — a non-custodial wallet SDK for AI agents.

**What it does:** Gives AI agents their own wallets with x402 HTTP payments, 17-chain CCTP bridging, ERC-6551 token-bound identity, and SpendingPolicy guardrails. The agent holds the keys — no custodian required.

**Why it fits:** Listed under SDKs and Libraries alongside Coinbase AgentKit and other agent infrastructure tools. Directly relevant to the agent ecosystem.

- npm: [agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk) (1,900+ weekly downloads)
- 113 passing tests, Base Mainnet + Sepolia support
- MIT licensed