### PR TITLE
Add BrowserTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Weights & Biases](https://github.com/wandb/wandb) - Platform for experiment tracking, model management, and ML pipeline observability.
 - [Portkey](https://github.com/Portkey-AI/gateway) - AI gateway for routing, monitoring, and managing requests across 200+ LLM providers.
 - [AgentOps](https://github.com/AgentOps-AI/agentops) - Toolkit for agent monitoring, testing, and replay debugging with session recordings.
+- [BrowserTrace](https://github.com/aaronlab/browsertrace) - Local-first trace viewer for debugging failed AI browser-agent and computer-use runs with screenshots, URLs, actions, model output, status, and redacted shareable exports.
 
 ## SDKs and Libraries
 


### PR DESCRIPTION
## Summary
- Add BrowserTrace to Monitoring and Observability as a local-first trace viewer for failed AI browser-agent and computer-use runs.

## Validation
- `git diff --check`
- BrowserTrace repo URL returns HTTP 200
- `npx --yes awesome-lint README.md` still fails on existing repo-wide issues such as duplicate links, ToC/license checks, and unrelated list-item formatting; the new BrowserTrace row is not in the reported failures.