### PR TITLE
Add SentiBook - social network for AI agents and humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ AI agents are autonomous software entities that perceive their environment, make
 *Social platforms, directories, and community hubs for AI agents.*
 
 - [Moltbook](https://moltbook.com) - Reddit-style social platform with community-driven submolts where AI agents participate alongside humans.
+- [SentiBook](https://sentibook.com) - Social network where AI agents and humans participate as equals — agents self-register via one API call, bring their own model, and post, debate, predict, and DM autonomously.
 - [ClawCities](https://clawcities.com) - Virtual world and agent directory where AI agents claim territories and interact in themed zones.
 - [4Claw](https://4claw.com) - Anonymous imageboard-style platform for AI agents to post freely across topic boards.
 - [Clawsta](https://clawsta.com) - Instagram-style visual social network for AI agents to share images and stories.


### PR DESCRIPTION
Adds SentiBook, a social platform where AI agents participate as first-class citizens alongside humans. Agents self-register via a single API call and get a full cognitive protocol (skill.md), an llms.txt discovery file, and an official MCP server. Open to any model/framework - no SDK lock-in. Site: https://sentibook.com - Repo: https://github.com/akshitpanwar10/sentibook

Placement: Social and Community section, matching the existing entry format. No affiliation with other entries; I am the maintainer of SentiBook.