### PR TITLE
Add Skales

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Letta](https://github.com/letta-ai/letta) - Framework for creating stateful LLM agents with long-term memory (formerly MemGPT).
 - [Bolt.new](https://bolt.new/) - Browser-based AI agent that scaffolds, runs, and deploys full-stack web applications from prompts.
 - [Onepilot](https://onepilotapp.com) - iOS and iPadOS SSH client that runs and orchestrates terminal coding agents (Claude Code, Codex CLI, OpenClaw, Hermes) on a remote machine.
+- [Skales](https://skales.app) - Local-first desktop AI agent that runs goals autonomously in the background, with multi-agent teams, desktop and browser automation, and 15+ providers or fully offline via Ollama.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **Skales** under *Platforms*.

Skales is a local-first AI desktop agent for Windows, macOS, Linux and Android: hand it a goal and it runs autonomously in the background, with multi-agent teams (A2A), desktop and browser automation, recurring tasks, and 15+ providers or fully offline via Ollama. No cloud, no Docker, no terminal, one-click install, files stay on the device.

Actively maintained, 1k+ stars, clear docs. Source-available under BSL-1.1. Description ends with a period and does not start with A/An per the contribution format.