### PR TITLE
Add Future AGI to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Langfuse](https://github.com/langfuse/langfuse) - Open-source LLM engineering platform with tracing, evaluations, prompt management, and metrics.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) - Open-source AI observability tool for monitoring and evaluating LLM applications in real time.
 - [Braintrust](https://www.braintrust.dev/) - End-to-end platform for evaluating, testing, and shipping AI products with confidence.
+- [Future AGI](https://github.com/future-agi/future-agi) - Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0.
 - [Weights & Biases](https://github.com/wandb/wandb) - Platform for experiment tracking, model management, and ML pipeline observability.
 - [Portkey](https://github.com/Portkey-AI/gateway) - AI gateway for routing, monitoring, and managing requests across 200+ LLM providers.
 - [AgentOps](https://github.com/AgentOps-AI/agentops) - Toolkit for agent monitoring, testing, and replay debugging with session recordings.


### PR DESCRIPTION
Adds [Future AGI](https://github.com/future-agi/future-agi) — an open-source platform to evaluate, trace, and guardrail LLM and agent applications with 70+ metrics and LLM-as-a-judge. Placed in the relevant evaluation/observability/tooling section to match the list's existing entries.