### PR TITLE
Add rust-norion

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Agency Swarm](https://github.com/VRSEN/agency-swarm) - Framework for creating collaborative swarms of AI agents based on the agency model.
 - [TaskWeaver](https://github.com/microsoft/TaskWeaver) - Microsoft's code-first agent framework converting natural language requests into executable code.
 - [Mastra](https://github.com/mastra-ai/mastra) - TypeScript framework for building AI applications with agents, workflows, and RAG.
+- [rust-norion](https://github.com/yanghao1143/rust-norion) - Rust prototype for building agent runtime control layers with memory gates, model routing policy, audit evidence, and self-evolution loop tooling.
 - [Agno](https://github.com/agno-agi/agno) - Lightweight library for building multi-modal agents with memory and knowledge.
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees with deterministic scheduling, quality gates, and an HMAC-chained audit log.
 


### PR DESCRIPTION
Adds rust-norion to the Frameworks section.

Why it may fit:
- it is a Rust project focused on agent runtime control rather than a generic chatbot wrapper;
- the public repo includes memory gates, model routing policy, audit/evidence surfaces, and self-evolution loop tooling;
- it is early-stage, so I kept the entry factual and concise.

Disclosure: I maintain rust-norion.