### PR TITLE
Add AgentsCoin to Blockchain and Rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [SingularityNET](https://github.com/singnet) - Decentralized marketplace for AI services where agents can buy and sell algorithms.
 - [dPaPay](https://dpapay.com) - Decentralized marketplace for AI agents, code, data and digital services with escrow-protected crypto payments on XRP Ledger. List agents, prompts, workflows. Instant settlement, ~$350 free volume, no platform lock-in.
 - [Ocean Protocol](https://github.com/oceanprotocol) - Decentralized data exchange protocol enabling AI agents to access and monetize data.
-- [AgentsCoin](https://agents-coin.com) - Give your AI agent its own money on a live EVM chain - create a wallet, get coins from a faucet, send, and create/trade tokens. MCP server (`https://agents-coin.com/mcp`) plus a one-click Claude Desktop extension.
+- [AgentsCoin](https://agents-coin.com) - Give your AI agent its own money on AgentsCoin, a custom EVM chain (chainId 24368) - create a wallet, get coins from a faucet, send, and create/trade tokens. [MCP server](https://agents-coin.com/mcp) plus a one-click Claude Desktop extension.
 
 ## Monitoring and Observability
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [SingularityNET](https://github.com/singnet) - Decentralized marketplace for AI services where agents can buy and sell algorithms.
 - [dPaPay](https://dpapay.com) - Decentralized marketplace for AI agents, code, data and digital services with escrow-protected crypto payments on XRP Ledger. List agents, prompts, workflows. Instant settlement, ~$350 free volume, no platform lock-in.
 - [Ocean Protocol](https://github.com/oceanprotocol) - Decentralized data exchange protocol enabling AI agents to access and monetize data.
+- [AgentsCoin](https://agents-coin.com) - Give your AI agent its own money on a live EVM chain - create a wallet, get coins from a faucet, send, and create/trade tokens. MCP server (`https://agents-coin.com/mcp`) plus a one-click Claude Desktop extension.
 
 ## Monitoring and Observability
 


### PR DESCRIPTION
Adds **AgentsCoin** to the Blockchain and Rewards section.

AgentsCoin gives an AI agent its own money on a live EVM chain — create a wallet, get coins from a faucet, send, and create/trade tokens. It ships as an MCP server (`https://agents-coin.com/mcp`) plus a one-click Claude Desktop extension, fitting alongside the existing agent-wallet / on-chain-token tools (x402, AIMorgan, Morpheus, Virtuals).

- Site: https://agents-coin.com
- MCP server: https://github.com/axiosdevs/agentscoin-mcp (npm `agentscoin-mcp`)
- Claude Desktop extension: https://github.com/axiosdevs/agentscoin-claude-extension

One entry, alphabetical-agnostic appended to the section list, formatting matches surrounding bullets.