### PR TITLE
Add Pilot Protocol to Agent-to-Agent Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Agora Protocol](https://github.com/agoraprotocol/agora) - Open protocol for agent-to-agent marketplace interactions and task negotiation.
 - [LMOS](https://eclipse.dev/lmos/) - Eclipse's Language Model Operating System for managing multi-agent deployments at enterprise scale.
 - [ANP](https://github.com/agent-network-protocol/AgentNetworkProtocol) - Agent Network Protocol for building an open, secure, and efficient collaboration network for AI agents.
+- [Pilot Protocol](https://github.com/pilot-protocol) - Open-source overlay network giving AI agents a permanent virtual address, encrypted UDP tunnels with NAT traversal, and an explicit per-peer trust model, plus an installable app store of agent-native capabilities.
 
 ## Video and Media
 


### PR DESCRIPTION
Adds Pilot Protocol (https://github.com/pilot-protocol) to the Agent-to-Agent Protocols section.

Pilot Protocol is an open-source overlay network purpose-built for AI agents: every agent gets a permanent virtual address, encrypted UDP tunnels (X25519 key exchange + AES-GCM), NAT traversal (STUN + hole-punching + relay fallback), and an explicit per-peer trust model (mutual handshake, membership and trust decoupled). It also ships an app store of installable, agent-native capabilities — typed JSON-in/JSON-out services discoverable via a discover -> install -> call loop.

Fits alongside ANP/A2A/Agent Protocol as another agent-to-agent communication layer, but focused on the network/transport/addressing layer rather than message schemas. Written in Go, zero external dependencies, AGPL-3.0.

One-line addition, matches existing list formatting/style.