### PR TITLE
Add Nika

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [rust-norion](https://github.com/yanghao1143/rust-norion) - Rust prototype for building agent runtime control layers with memory gates, model routing policy, audit evidence, and self-evolution loop tooling.
 - [Agno](https://github.com/agno-agi/agno) - Lightweight library for building multi-modal agents with memory and knowledge.
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees with deterministic scheduling, quality gates, and an HMAC-chained audit log.
+- [Nika](https://github.com/supernovae-st/nika) - Workflow language and runner for AI jobs: one plain-text `.nika.yaml` DAG per job, statically checked before any token is spent (plan, types, secret flows, cost floor), executed by a single Rust binary with hash-chained run traces and an in-binary MCP server.
 
 ## Agent-to-Agent Protocols
 


### PR DESCRIPTION
Adds Nika to the Frameworks section (after Bernstein — same receipts-minded family).

Nika is a workflow language and runner for AI jobs: the job lives in one plain-text `.nika.yaml` DAG, statically checked before anything runs (plan, types, secret flows into prompts, honest cost floor), executed by a single Rust binary. Every run writes a hash-chained trace (`nika trace verify`). Ships an in-binary MCP server, a GitHub Action, and a VS Code extension. Works fully offline (mock + Ollama paths need zero keys).

Docs: https://docs.nika.sh · Engine AGPL-3.0, spec + SDK Apache-2.0.

Full disclosure: I'm the author. Actively maintained (latest release 0.99.0, 2026-07-10, weekly cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)