### PR TITLE
Add Agent Passport System (APS) to Standards and Specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Tool Use Schemas](https://json-schema.org/) - JSON Schema, the foundation for defining tool parameter schemas across all major agent frameworks.
 - [OAuth 2.0](https://oauth.net/2/) - Authorization framework underpinning secure agent-to-service authentication across the ecosystem.
 - [WebSocket Protocol](https://datatracker.ietf.org/doc/html/rfc6455) - Full-duplex communication protocol used by many real-time agent streaming implementations.
+- [Agent Passport System (APS)](https://datatracker.ietf.org/doc/draft-pidlisnyi-aps/) - IETF Internet-Draft specifying verifiable agent identity, faceted authority that can only attenuate across seven constraint dimensions, deterministic action and decision references, and a common envelope for signed action receipts. Defines bindings for MCP tool calls and imported OAuth identity-assertion grants.
 
 ## Edge and Retro Inference
 


### PR DESCRIPTION
Adds the Agent Passport System to **Standards and Specifications**.

APS is an IETF Internet-Draft (draft-pidlisnyi-aps-03) that specifies verifiable agent identity, faceted authority that can only attenuate across seven constraint dimensions (scope, spend, depth, time, reputation, values, reversibility), deterministic action and decision references, and a common envelope for signed action receipts. It defines bindings for Model Context Protocol tool calls and imported OAuth identity-assertion authorization grants.

It sits alongside the existing protocol-spec entries in that section (A2A, MCP, OAuth 2.0). Entry follows the section's format, one line, description ending with a period. No adoption or production claims.
