### PR TITLE
Add Orkas to platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Skales](https://skales.app) - Local-first desktop AI agent that runs goals autonomously in the background, with multi-agent teams, desktop and browser automation, and 15+ providers or fully offline via Ollama.
 - [Hivekeep](https://github.com/MarlBurroW/hivekeep) - Self-hosted platform to run a team of specialized AI agents with persistent memory and a web UI, reachable over Telegram, Slack, Discord and Matrix, in a single Bun and SQLite container.
 - [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs unattended on GitHub Actions, on a cron schedule or reactive repo triggers, dispatching Markdown skills to one of six coding-agent harnesses (Claude Code, Codex, Grok, Pi, Vibe, Kimi) with quality scoring, git-persisted memory, and a self-healing loop.
+- [Orkas](https://orkas.ai?source=gh-scott) - Open-source, local-first desktop AI workforce where a Commander coordinates specialist agents through one chat ([source](https://github.com/Orkas-AI/Orkas)).
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary
- add Orkas to the Platforms section
- link the official website with a distinct source tag and the MIT-licensed repository

## Why it fits
Orkas is an open-source, local-first desktop AI workforce. A Commander coordinates specialist agents in parallel or sequence through one chat, and users bring their own model keys.

## Verification
- Official site: https://orkas.ai?source=gh-scott
- Source: https://github.com/Orkas-AI/Orkas