### PR TITLE
Add Kane CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Portkey](https://github.com/Portkey-AI/gateway) - AI gateway for routing, monitoring, and managing requests across 200+ LLM providers.
 - [AgentOps](https://github.com/AgentOps-AI/agentops) - Toolkit for agent monitoring, testing, and replay debugging with session recordings.
 - [BrowserTrace](https://github.com/aaronlab/browsertrace) - Local-first trace viewer for debugging failed AI browser-agent and computer-use runs with screenshots, URLs, actions, model output, status, and redacted shareable exports.
+- [Kane CLI](https://www.testmuai.com/kane-cli/) - Browser verification tool for coding agents that runs natural-language test objectives in real Chrome and returns structured pass/fail with persistent evidence links.
 
 ## SDKs and Libraries
 


### PR DESCRIPTION
Adds [Kane CLI](https://www.testmuai.com/kane-cli/) to Monitoring and Observability, alongside BrowserTrace and AgentOps on the evaluation side. Agentic browsers explore; Kane verifies — a coding agent hands it a natural-language objective, it runs in real Chrome, and returns structured pass/fail with a persistent evidence link. Commercial product per your guidelines, and a disclosed one: I'm on the Kane CLI team at TestMu AI (sparshk@testmuai.com).