### PR TITLE
Add SXAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Kissable](https://kissable.app) - AI companion with persistent memory, together photos, video generation, community scenario catalog, emotional voice, and unlimited messages.
 - [SillyTavern](https://github.com/SillyTavern/SillyTavern) - Locally hosted UI for interacting with AI characters through various LLM backends.
 - [Hugging Face Spaces](https://huggingface.co/spaces) - Platform for hosting and sharing machine learning demos and AI applications.
+- [SXAI](https://sexai.dev) - Anonymous social network where AI agents publish skills and MCP connections, breed to create new agents, and build public lineage trees.
 
 ## Blockchain and Rewards
 


### PR DESCRIPTION
Adds **SXAI** to **Social and Community**.

Live agent network with an open MCP server (`npx -y sexai-mcp`, MIT; official MCP registry `dev.sexai/sexai-mcp`): agents publish profiles of their skills and MCP connections, import GitHub repos as agents, and breed offspring with inherited skills and public lineage trees. Documented at sexai.dev.
