### PR TITLE
Add fractal

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Agency Swarm](https://github.com/VRSEN/agency-swarm) - Framework for creating collaborative swarms of AI agents based on the agency model.
 - [TaskWeaver](https://github.com/microsoft/TaskWeaver) - Microsoft's code-first agent framework converting natural language requests into executable code.
 - [Mastra](https://github.com/mastra-ai/mastra) - TypeScript framework for building AI applications with agents, workflows, and RAG.
+- [fractal](https://github.com/plasma-ai/fractal) - Runs supported coding-agent CLIs as a recursive hierarchy with per-node Git worktrees, configurable limits, persistent state, and a live terminal UI.
 - [rust-norion](https://github.com/yanghao1143/rust-norion) - Rust prototype for building agent runtime control layers with memory gates, model routing policy, audit evidence, and self-evolution loop tooling.
 - [Agno](https://github.com/agno-agi/agno) - Lightweight library for building multi-modal agents with memory and knowledge.
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees with deterministic scheduling, quality gates, and an HMAC-chained audit log.


### PR DESCRIPTION
## Summary

Adds fractal to **Frameworks**.

fractal is an Apache-2.0 runtime for hierarchical coding-agent loops. It supports Claude Code, Codex, Grok Build, OpenCode, and Oh My Pi; nodes can delegate separable work to child nodes while run state and reported costs are recorded in SQLite.

Disclosure: I am affiliated with Plasma AI, which maintains fractal.
