### PR TITLE
Add agent-kit: secure per-customer TypeScript agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [rust-norion](https://github.com/yanghao1143/rust-norion) - Rust prototype for building agent runtime control layers with memory gates, model routing policy, audit evidence, and self-evolution loop tooling.
 - [Agno](https://github.com/agno-agi/agno) - Lightweight library for building multi-modal agents with memory and knowledge.
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees with deterministic scheduling, quality gates, and an HMAC-chained audit log.
+- [agent-kit](https://github.com/socialrobot-io/agent-kit) - Secure per-customer TypeScript agents with sandboxed execution, curated memory, and human-gated learning. Built on Vercel AI SDK and AgentFS.
 
 ## Agent-to-Agent Protocols
 


### PR DESCRIPTION
Adds [agent-kit](https://github.com/socialrobot-io/agent-kit) to the Frameworks section.

I had this issue where I needed secure AI agents for each one of my customers: agents that learn the nuances of each customer, but are secure by default, and ready to put into production with no complex infrastructure. Everything I tried fell short, so I built agent-kit.

Per-customer isolation, sandboxed execution by default, curated memory with human approval, no complex infrastructure. Built on Vercel AI SDK and AgentFS. TypeScript, Bun and Node.js, MIT licensed.