### PR TITLE
Add Aeon to Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Onepilot](https://onepilotapp.com) - iOS and iPadOS SSH client that runs and orchestrates terminal coding agents (Claude Code, Codex CLI, OpenClaw, Hermes) on a remote machine.
 - [Skales](https://skales.app) - Local-first desktop AI agent that runs goals autonomously in the background, with multi-agent teams, desktop and browser automation, and 15+ providers or fully offline via Ollama.
 - [Hivekeep](https://github.com/MarlBurroW/hivekeep) - Self-hosted platform to run a team of specialized AI agents with persistent memory and a web UI, reachable over Telegram, Slack, Discord and Matrix, in a single Bun and SQLite container.
+- [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs unattended on GitHub Actions, on a cron schedule or reactive repo triggers, dispatching Markdown skills to one of six coding-agent harnesses (Claude Code, Codex, Grok, Pi, Vibe, Kimi) with quality scoring, git-persisted memory, and a self-healing loop.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **Aeon** to **Platforms**.

Aeon is an autonomous, fork-and-run agent framework that runs unattended on GitHub Actions (cron or reactive repo triggers) - the same self-hosted / autonomous-background neighborhood as SuperAGI, Skales, and Hivekeep already in this section. It dispatches each Markdown skill to one of six coding-agent harnesses (Claude Code, Codex, Grok, Pi, Vibe, Kimi) behind one contract, with output quality scoring, git-persisted memory, and a self-healing loop.

---
Aeon: https://github.com/aeonfun/aeon (MIT, ~589 stars, actively maintained). Disclosure: I work on Aeon. Single entry; happy to adjust wording or placement.
