### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Skales](https://skales.app) - Local-first desktop AI agent that runs goals autonomously in the background, with multi-agent teams, desktop and browser automation, and 15+ providers or fully offline via Ollama.
 - [Hivekeep](https://github.com/MarlBurroW/hivekeep) - Self-hosted platform to run a team of specialized AI agents with persistent memory and a web UI, reachable over Telegram, Slack, Discord and Matrix, in a single Bun and SQLite container.
 - [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs unattended on GitHub Actions, on a cron schedule or reactive repo triggers, dispatching Markdown skills to one of six coding-agent harnesses (Claude Code, Codex, Grok, Pi, Vibe, Kimi) with quality scoring, git-persisted memory, and a self-healing loop.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding assistant that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required, 56 built-in tools across browser, filesystem, git, memory, and vision, MCP support, and a five-layer local memory system on macOS, Linux, and Windows.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **Atomic Agent** to **Platforms**.

Hi! I'm the CPO of Atomic Agent. Thanks for putting this list together, it's genuinely one of the more carefully curated agent lists out there, and our team would be thrilled if you added us.

Atomic Agent is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so there's no account or API key needed to install or run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and has a five-layer local memory system. The TUI is built on React and ink. Cross-platform on macOS, Linux, and Windows.

Install: `curl -fsSL https://atomicagent.io/install | sh`

It sits in the same terminal-and-desktop coding-agent neighborhood as Claude Code, OpenHands, and Skales, which are already in Platforms, with the local-model angle as the main difference.

Links:
- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT, ~2k stars, actively maintained)
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

On the contribution format: single entry, single PR, description ends with a period and does not begin with "A" or "An", link points to the primary GitHub repo.

One honest note on maturity: the repo is about 4 months old. It is active and maintained by the AtomicBot-ai organization, which ships several established projects. Happy to adjust the wording, shorten the description, or move the placement if you'd prefer it elsewhere.
