### PR TITLE
Add SandBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ AI agents are autonomous software entities that perceive their environment, make
 *Servers and connectors that expose business data, SaaS APIs, and external tools to agents through MCP or related interfaces.*
 
 - [CorpusIQ](https://github.com/CorpusIQ/corpusiq-docs) - Open-source MCP server that connects AI agents to business data APIs such as Stripe, GA4, Shopify, QuickBooks, and HubSpot.
+- [SandBase](https://github.com/sandbaseai/cli) - Open-source CLI and local MCP bridge giving AI agents unified access to 2,000+ AI models and APIs.
 
 ## Video and Media
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ AI agents are autonomous software entities that perceive their environment, make
 *Servers and connectors that expose business data, SaaS APIs, and external tools to agents through MCP or related interfaces.*
 
 - [CorpusIQ](https://github.com/CorpusIQ/corpusiq-docs) - Open-source MCP server that connects AI agents to business data APIs such as Stripe, GA4, Shopify, QuickBooks, and HubSpot.
-- [SandBase](https://github.com/sandbaseai/cli) - Open-source CLI and local MCP bridge giving AI agents unified access to 2,000+ AI models and APIs.
+- [SandBase](https://github.com/sandbaseai/cli) - Open-source CLI and local MCP bridge giving AI agents unified access to 2,000+ AI models.
 
 ## Video and Media
 


### PR DESCRIPTION
## Summary

- add SandBase to MCP Servers and Data Connectors
- describe its open-source CLI and local MCP bridge for 2,000+ AI models
- keep the entry concise and in the repository's required format

## Why it qualifies

SandBase is directly useful to AI agents: its local MCP bridge exposes a unified model and API catalog to supported agent clients. The repository is Apache-2.0 licensed, documented, and actively maintained.

## Validation

- confirmed there is no existing entry or open SandBase submission
- changed only `README.md`
- preserved the repository's existing line endings
- ran `git diff --check`

## Disclosure

I am affiliated with SandBase. This submission was prepared with AI assistance and reviewed for factual accuracy and repository fit.