### PR TITLE
Add Mobile SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Skales](https://skales.app) - Local-first desktop AI agent that runs goals autonomously in the background, with multi-agent teams, desktop and browser automation, and 15+ providers or fully offline via Ollama.
 - [Hivekeep](https://github.com/MarlBurroW/hivekeep) - Self-hosted platform to run a team of specialized AI agents with persistent memory and a web UI, reachable over Telegram, Slack, Discord and Matrix, in a single Bun and SQLite container.
 - [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs unattended on GitHub Actions, on a cron schedule or reactive repo triggers, dispatching Markdown skills to one of six coding-agent harnesses (Claude Code, Codex, Grok, Pi, Vibe, Kimi) with quality scoring, git-persisted memory, and a self-healing loop.
+- [Mobile SSH](https://mobile-ssh.github.io) - Android and iOS SSH client that runs terminal coding agents (Claude Code, Codex) on remote machines, with a multi-server tmux session manager and phone alerts when an agent is waiting on input.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds **Mobile SSH** to `## Platforms`, appended at the end of the category as the contributing guidelines require.

Mobile SSH is an Android and iOS SSH/SFTP/terminal client for running terminal coding agents — Claude Code, Codex — on remote machines from a phone. It sits in the same slot as the existing Onepilot entry, with two differences: it runs on Android as well as iOS, and it raises a phone notification the moment a remote agent is waiting on input (integrating with Claude Code's documented `agent_needs_input` / `agent_completed` notification hooks rather than scraping the terminal). It also ships a multi-server tmux session/window/pane manager, so you can attach to the session the agent is running in and answer it directly.

Website: https://mobile-ssh.github.io

Disclosure: I am the author. The app is free — no account, no cloud, no ads, no paid tier. It is closed source; per CONTRIBUTING, open source is preferred but not required. Android is currently a Google Play closed test and iOS is a public TestFlight beta, so install links are on the website rather than a store listing — happy to close this and resubmit after the public listings land if you would rather wait.

Format follows the guidelines: `[Name](link) - Description.`, ends with a period, does not begin with "A"/"An". Single line added, nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
