### PR TITLE
Add YYLO to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ AI agents are autonomous software entities that perceive their environment, make
 - [Agno](https://github.com/agno-agi/agno) - Lightweight library for building multi-modal agents with memory and knowledge.
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees with deterministic scheduling, quality gates, and an HMAC-chained audit log.
 - [agent-kit](https://github.com/socialrobot-io/agent-kit) - Secure per-customer TypeScript agents with sandboxed execution, curated memory, and human-gated learning. Built on Vercel AI SDK and AgentFS.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes, with typed task, validation, merge, and release-readiness boundaries; each task works in a dedicated branch/worktree and the merge queue owns risk-based review. MIT, on npm as @yylo/cli.
 
 ## Agent-to-Agent Protocols
 


### PR DESCRIPTION
Adds [YYLO](https://github.com/yylo-dev/yylo) to the **Frameworks** section — one line, appended at the section bottom.

**Why Frameworks:** the section already houses the closest neighbors — Bernstein ("orchestrator that drives 40+ CLI coding agents … in parallel git worktrees … quality gates … audit log"), rust-norion (agent runtime control layers with audit evidence), and agent-kit. YYLO is the same kind of developer-facing orchestration layer: a command-line orchestrator for coding agents (it drives Pi and Codex subagents) that gives each task typed task, validation, merge, and release-readiness boundaries, runs it in a dedicated branch/worktree, and routes it through a merge queue that owns risk-based review, producing receipt-backed repository changes.

**Qualifies per CONTRIBUTING:** directly AI-agent related; actively maintained (pushes within the last week, repo since January 2026); documented README with install and usage (`npm install --global @yylo/cli`, commands `yylo` / `yy`); MIT-licensed; 57 GitHub stars.

**Format:** `[Name](link) - Description.` per the guidelines; individual PR for a single suggestion; searched existing entries for duplicates (none — YYLO is not currently listed).

**Disclosure:** I'm on the team that builds YYLO, and this PR was prepared with AI assistance — both called out up front (following the house practice of #23, which disclosed AI assistance and merged).

**Validation:** `git diff --check` clean; single-file `+1/−0` diff on README.md only.
